### PR TITLE
BOJ 19941: 햄버거 분배

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj19941.java
+++ b/kimdaeyeong/src/baekjoon/Boj19941.java
@@ -1,0 +1,65 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+public class Boj19941 {
+
+    static int n;
+    static int k;
+    static char[] c;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken()); // 식탁의 길이
+        k = Integer.parseInt(st.nextToken()); // 햄버거를 선택할 수 있는 거리
+
+        st = new StringTokenizer(br.readLine());
+        c = st.nextToken().toCharArray();
+
+        System.out.println(divide());
+    }
+
+    public static int divide() {
+        int cnt = 0;
+
+        for(int i = 0; i < n; i++) {
+            if(c[i] == 'P') {
+                int cur = i - k;
+                boolean check = false;
+
+                while(cur < i) {
+                    if(cur < 0) {
+                        cur++;
+                        continue;
+                    }
+
+                    if(c[cur] == 'H') {
+                        check = true;
+                        c[cur] = 'X';
+                        cnt++;
+                        break;
+                    }
+                    cur++;
+                }
+
+                if(check)
+                    continue;
+
+                cur = i;
+                for(int j = 1; j <= k; j++) {
+                    cur += 1;
+                    if(cur < n && c[cur] == 'H') {
+                        c[cur] = 'X';
+                        cnt++;
+                        break;
+                    }
+                }
+            }
+        }
+
+        return cnt;
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 19941: 햄버거 분배](https://www.acmicpc.net/problem/19941)
<br>

## 📱 스크린샷
<img width="735" alt="image" src="https://github.com/kdozlo/algorithm-study/assets/74356213/47fc83d9-ee09-4241-8ea7-5eef1087deda">
<br>

## 📝 리뷰 내용
오른쪽, 왼쪽 선택, 거리 선택해서 bfs 완전탐색이라고 생각했습니다. 하지만! 범위를 봤을때 모든 경우의 수를 고려하면 시간초과 날 것 같았습니다. 또한 문제 유형이 그리디 냄세가 딱 나서 바로 방향 바꿔서 구현 했습니다.

핵심 로직은 사람 기준 왼쪽은 먼 햄버거 순으로 먹고, 오른쪽은 가까운 햄버거 순으로 먹는다면 최대한 많은 인원이 먹을 수 있다고 판단했습니다. 하지만 코드 구현 과정에서 오른쪽도 먼 햄버거 순으로 먹어서 틀렸습니다.... 결론은 코드를 생각하면서 잘 짜자 입니다...

추가로 왼쪽은 가까운 기준, 오른쪽은 먼 기준도 고려해야 하지 않을까 생각해봤는데 이건 사람 탐색 방향이 오른쪽이라서 이 경우는 최대로 먹는 경우가 안나올수도 있다가 결론입니다.  
