### PR TITLE
BOJ 9017: 크로스 컨트리

### DIFF
--- a/limsubin/baekjoon/boj9017.py
+++ b/limsubin/baekjoon/boj9017.py
@@ -1,0 +1,52 @@
+# BOJ 9017: 크로스 컨트리
+# https://www.acmicpc.net/problem/9017
+
+import sys
+from collections import defaultdict
+
+def input():
+    return sys.stdin.readline().strip()
+
+t = int(input())
+
+for _ in range(t):
+    n = int(input())
+    info = list(map(int, input().split()))
+
+    # 팀 별 참가자 수 저장
+    team = defaultdict(int)
+    for i in range(n):
+        team[info[i]] += 1
+
+    # 팀 별 점수 계산
+    s = 0
+    score = {}
+    for i in range(n):
+        # 참가자가 6명 미만인 팀 제외
+        if team[info[i]] < 6:
+            continue
+
+        # 점수 저장
+        s += 1
+        if info[i] in score:
+            score[info[i]].append(s)
+        else:
+            score[info[i]] = [s]
+
+    best = float('INF')
+    for i in score:
+        cur = sum(score[i][:4])
+
+        # 상위 4명 점수의 합이 가장 낮은 팀이 우승
+        if cur < best:
+            answer = i
+            best = cur
+            continue
+        # 동점일 경우
+        if cur == best:
+            # 다섯 번째 주자가 가장 빨리 들어온 팀이 우승
+            if score[i][4] < score[answer][4]:
+                answer = i
+                continue
+
+    print(answer)


### PR DESCRIPTION
## 💡 문제
BOJ 9017: 크로스 컨트리
<br>

## 📱 스크린샷
<img width="1148" alt="image" src="https://github.com/user-attachments/assets/08200507-db97-4b42-a24f-afa53332e962">
<br>

## 📝 리뷰 내용
문제에서 요구하는 대로 그대로 구현하면 되는 문제였습니다.

1. 딕셔너리(맵)를 이용해서 팀 별 점수를 먼저 계산하고
2. 상위 4명 점수 + 5번째 주자의 점수를 보고 우승 팀을 결정

푸는데 은근 시간이 오래 걸렸는데,, `여섯 명의 주자가 참가하지 못한 팀은 점수 계산에서 제외된다.` 이 조건을 똑바로 안 봐서 포함해서 점수를 계산한 후 마지막에 거르는 식으로 해서 테스트케이스에서 틀린 걸 보고 고쳤습니다ㅠ 문제를 꼼꼼히 읽어야겠어유,,
