### PR TITLE
BOJ 18429: 근손실

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj18429.java
+++ b/kimdaeyeong/src/baekjoon/Boj18429.java
@@ -1,0 +1,2 @@
+package baekjoon;public class Boj18429 {
+}

--- a/kimdaeyeong/src/baekjoon/Boj18429.java
+++ b/kimdaeyeong/src/baekjoon/Boj18429.java
@@ -1,2 +1,68 @@
-package baekjoon;public class Boj18429 {
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 18429
+ * 근손실
+ * 실버3
+ * https://www.acmicpc.net/problem/18429
+ */
+public class Boj18429 {
+
+    static int n; // number of kit
+    static int k; // decrease per day
+    static int[] kit; // exercise kit
+    static int answer = 0; // number of over 500 everyday
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        st = new StringTokenizer(br.readLine());
+        kit = new int[n];
+        for(int i = 0; i < n; i++)
+            kit[i] = Integer.parseInt(st.nextToken());
+
+        permutation(new boolean[n], new int[n], 0);
+
+        System.out.println(answer);
+    }
+
+    public static void permutation(boolean[] checked, int[] array, int depth) {
+        if(depth == n) {
+
+            // check over 500 everyday
+            if(checkingOver500(array))
+                answer++;
+
+            return;
+        }
+
+        for(int i = 0; i < n; i++) {
+            if(checked[i])
+                continue;
+
+            checked[i] = true;
+            array[depth] = i;
+            permutation(checked, array, depth + 1);
+            checked[i] = false;
+        }
+    }
+
+    public static boolean checkingOver500(int[] array) {
+
+        int cur = 500;
+        for(int i : array) {
+            cur += kit[i] - k;
+
+            if(cur < 500)
+                return false;
+        }
+
+        return true;
+    }
 }


### PR DESCRIPTION
## 💡 문제
[BOJ 18429: 근손실](https://www.acmicpc.net/problem/18429)
<br>

## 📱 스크린샷
<img width="733" alt="image" src="https://github.com/user-attachments/assets/4b1183e6-2721-4f8f-bf52-4c2ba3db306c">
<br>

## 📝 리뷰 내용
조합을 이용해서 운동 키트를 사용할 수 있는 모든 경우의 수를 찾아 항상 500이 넘는지 체크하도록 구현했습니다. 범위를 봐도 완탐하기에 충분하기 때문에 어렵지 않게 풀었네요. 하지만 다른 사람 코드와 보니 속도가 좀 느려서 확인해 보니까 제 코드의 경우 모든 경우의 수를 찾은 다음 조건이 만족하는지 체크하도록 구현했어요. 하지만 속도를 높이려면 모든 경우의 수를 찾지 말고 경우의 수를 찾는 과정에서 매일 500이 넘는지를 체크해 안넘는다면 찾지 안도록 해야 되네요. 이부분이 오늘의 배울점이였습니다.!
