### PR TITLE
BOJ 4883: 삼각 그래프

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj4883.java
+++ b/kimdaeyeong/src/baekjoon/Boj4883.java
@@ -1,0 +1,65 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 4883
+ * 삼각 그래프
+ * 실버1
+ * https://www.acmicpc.net/problem/4883
+ */
+public class Boj4883 {
+
+    static int n; // 행의 개수
+    static int[][] g; // 그래프
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        StringBuilder sb = new StringBuilder();
+
+        int k = 0; // 테스트 케이스 번호
+        while((n = Integer.parseInt(st.nextToken())) != 0) {
+            k++;
+
+            g = new int[n][3];
+            int[][] dp = new int[n][3];
+            for(int i = 0; i < n; i++) {
+                st = new StringTokenizer(br.readLine());
+                for(int j  =0; j < 3; j++) {
+                    g[i][j] = Integer.parseInt(st.nextToken());
+                    dp[i][j] = 1000000;
+                }
+            }
+
+            // 첫번째 행
+            dp[0][1] = g[0][1];
+            dp[0][2] = dp[0][1] + g[0][2];
+
+            // 두번째 행
+            dp[1][0] = dp[0][1] + g[1][0];
+            dp[1][1] = Math.min(Math.min(dp[0][1], dp[0][2]), dp[1][0]) + g[1][1];
+            dp[1][2] = Math.min(Math.min(dp[0][1], dp[0][2]), dp[1][1]) + g[1][2];
+
+            // 세번째 행부터
+            for(int i = 2; i < n; i++) {
+
+                dp[i][0] = Math.min(dp[i - 1][0], dp[i - 1][1]) + g[i][0];
+
+                dp[i][1] = Math.min(
+                        Math.min(
+                                Math.min(dp[i - 1][0], dp[i - 1][1])
+                                , dp[i - 1][2])
+                        , dp[i][0]) + g[i][1];
+
+                dp[i][2] = Math.min(Math.min(dp[i - 1][1], dp[i - 1][2]), dp[i][1]) + g[i][2];
+            }
+
+            sb.append(k).append(".").append(" ").append(dp[n - 1][1]).append("\n");
+            st = new StringTokenizer(br.readLine());
+        }
+
+        System.out.println(sb.toString());
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 4883: 삼각 그래프](https://www.acmicpc.net/problem/4883)
<br>

## 📱 스크린샷
<img width="729" alt="image" src="https://github.com/user-attachments/assets/caea81dc-6db5-4590-981b-dfb8518879b4">
<br>

## 📝 리뷰 내용
첫번째 시도 
우선순위 큐를 이용한 다익스트라를 통해 구현했습니다. 하지만 음수 가중치의 경우를 생각하지 못해 틀렸습니다. 
예시 data
2
0 0 -1
0 -2 0
정답 : 1. -3
코드답: 1. -2

두번째 시도
첫번째 방법과 동일하기 우선순위 큐를 이용한 다익스트라로 구현 했습니다. 하지만 현재 가중치값이 현재 목표지점까지의 최솟값보다 큰 경우 탐색을 못하도록 하는 조건을 뺐습니다. 이렇게 하면 다익스트라일지라도 같은 노드의 재방문이 가능해지기 때문에 위의 예시 data에 대한 답이 정확하게 나왔습니다. 하지만 이 경우 시간초과가 발생합니다.

이유는 다익스트라의 경우 시간복잡도가 O(E long V) 입니다. 현재 문제이서 정점은 n(최대 100,000)이고 간선은 각 노드당 최대 4개가 있으므로  4n이라고 할 수 있습니다. 따라서 다익스트라로 푼 경우 시간 복잡도는 nlogn 입니다. 이렇게 보면 n의 최대 길이가 100,000이므로 시간초과가 안날것으로 보이지만 현재 문제는 여러 테스트케이스가 들어갈 수 있습니다. 따라서 nlogn보다 작은 시간 복잡도로 현재 문제를 풀어야 한다는 것을 알 수 있습니다.

마지막 시도
1. 현재 문제에서 정점의 최대 수는 3 * 100,000 = 300,00이고, 간선의 최대 수는 300,000 * 4 = 1,200,000 입니다. 이렇게 큰 그래프에서 다익스트라 알고리즘의 효율성은 좋지 않습니다. 또한 음수 가중치가 있을 경우 기본 다익스트라 개념과는 거리가 있습니다.

2. 경로의 방향성이 한정적이고, 부분 최적 비용을 통해 전체 최적 비용을 구할 수 있습니다.

1번과 2번의 내용을 통해 현재 문제는 dp유형임을 알 수 있습니다. (dp의 경우 시간복잡도는 O(n))
규칙성은 코드를 보시면서, 그래프를 대입해 보시면 금방 알 수 있기 때문에 따로 적지 않겠습니다.

느낀점
까먹고 있던 다익스트라의 개념을 다시 한번 복습할 수 있는 좋은 기회가 되었고, 문제 유형을 파악하는 능력이 얼마나 중요한지 알게 되는 문제 였습니다.(이번 문 제 시간 초과 나고 어떤 유형인지 보고 풀었어요...) 갈길이 머네요... 

