### PR TITLE
BOJ 22251: 빌런 호석

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj22251.java
+++ b/kimdaeyeong/src/baekjoon/Boj22251.java
@@ -1,0 +1,91 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 22251
+ * 빌런 호석
+ * 골드5
+ * https://www.acmicpc.net/problem/22251
+ */
+public class Boj22251 {
+
+    // 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+    static boolean[][] digit = {
+            {true, true, true, false, true, true, true},
+            {false, false, false, false, false, true, true},
+            {false, true, true, true, true, true, false},
+            {false, false, true, true, true, true, true,},
+            {true, false, false, true, false, true, true},
+            {true, false, true, true, true, false, true},
+            {true, true, true, true, true, false, true},
+            {false, false, true, false, false, true, true},
+            {true, true, true, true, true, true, true},
+            {true, false, true, true, true, true, true},
+    };
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int n = Integer.parseInt(st.nextToken()); // 총 엘리베이터 층수
+        int k = Integer.parseInt(st.nextToken()); // k자리 수
+        int p = Integer.parseInt(st.nextToken()); // 최대 반전 가능 횟수
+        int x = Integer.parseInt(st.nextToken()); // 현재 층수
+
+        int answer = 0;
+
+
+        int[][] change = new int[10][10]; // i에서 j로 숫자를 바꿀 때 반전 횟수
+        for(int i = 0; i < 10; i++) {
+            for(int j = 0; j < 10; j++) {
+                change[i][j] = dif(i, j);
+            }
+        }
+
+        // 1부터 n(엘리베이터 마지막 층수)까지의 숫자와 현재 층수를 비교하여 몇번 반전 해야 바꿀 수 있는지 확인
+        for(int i = 1; i <= n; i++) {
+            if(i == x)
+                continue;
+
+            int curP = 0;
+            boolean flag = true;
+            int n1 = x;
+            int n2 = i;
+
+            // 자리수 별 반전 횟수 구하기
+            for(int j = 1; j <= k; j++) {
+                curP += change[n1 % 10][n2 % 10];
+                n1 /= 10;
+                n2 /= 10;
+                // 최대 반전 횟수 초과인 경우
+                if(curP > p) {
+                    flag = false;
+                    break;
+                }
+            }
+
+            if(flag) {
+                answer++;
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    // n1에서 n2가 되기 위한 반전 횟수
+    public static int dif(int n1, int n2) {
+        boolean[] b1 = digit[n1].clone();
+        boolean[] b2 = digit[n2].clone();
+
+        int cnt = 0;
+
+        for(int i = 0; i < 7; i++) {
+            if(b1[i] != b2[i])
+                cnt++;
+        }
+
+        return cnt;
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 22251: 빌런 호석](https://www.acmicpc.net/problem/22251)
<br>

## 📱 스크린샷
<img width="731" alt="image" src="https://github.com/user-attachments/assets/20f68dd3-3df7-4d7e-beb8-84c80e7021f1">
<br>

## 📝 리뷰 내용
이 문제는 로직을 중간에 1번 변경하였습니다.
일단 0 ~ 9 숫자을 디지털화 했을 때 불이 들어오고 안 들어오는 형태를 boolean[][]로 저장하였습니다. 행은 해당 숫자, 열은 불의 켜짐 여부 입니다. 불이 켜진 경우 true, 꺼진 경우가 false입니다.

첫번째 로직
반전 횟수를 중심으로 구현했습니다. 하나의 숫자당 반전 횟수별로 변경 숫자를 데이터에 넣었습니다. 각 자리수별로 반전 할 위치를 순열로 구하면서 중간에 최대 반전 횟수도 체크합니다. 그리고 반전 위치를 구한 후 반전 했을 때의 숫자가 있는 경우 또한 생각했습니다.
하지만 이 로직은 문제점이 있습니다. 첫번째로 최대 엘리베이터 층수 가 정해져 있어 모든 자리수의 반전 체크가 끝난 뒤의 숫자와 최대 엘리베이터 층 수를 비교해야 하는데 현재 로직에서는 자리별로 반전 가능한 모든 횟수를 구하기 때문이 이러한 비교가 어렵습니다. 두번째는 각 자리마다 순열 로직이 돌기 때문에 느리다는 점입니다.

두번째 로직
 첫번재 로직의 문제점들을 해결할 방법은 바로 반전 횟수 중심이 아닌 바꿀 층수 중심으로 구현하면 되는것 입니다.
먼저 "int[현재 층수][바꿀 층수] = 반전 횟수" 데이터를 위의 "boolean[숫자][불 켜짐 여부]"로 미리 구합니다.
그 다음 1부터 최대 층수까지의 숫자들과 현재 층수를 자리수 별로 비교하면서 반전 횟수를 체크 합니다. 
마지막으로 반전 횟수가 최대 반전 횟수를 넘어서는지 비교하며 정답을 구하면 됩니다.

느낀점
생각한 로직으로 풀기 어렵다면 현재 구현의 중심 방향을 틀어서 생각해보면 의외로 구현이 간단해진다는것을 느꼈습니다. 
