### PR TITLE
BOJ 1515: 수 이어 쓰기

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj1515.java
+++ b/kimdaeyeong/src/baekjoon/Boj1515.java
@@ -1,0 +1,43 @@
+package baekjoon;
+
+import java.io.*;
+
+/**
+ * 백준 1515
+ * 수 이어 쓰기
+ * 실버3
+ * https://www.acmicpc.net/problem/1515
+ */
+public class Boj1515 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        char[] array = br.readLine().toCharArray();
+        int cur = Character.getNumericValue(array[0]);
+        int i = 0;
+
+        if(cur == 0)
+            cur = 1;
+
+        // 받은 숫자 한자리씩 비교
+        while(i != array.length) {
+
+            //받은 숫자의 한자리와 현재 나와야하는 숫자 하나씩 비교
+            for(char c : (cur + "").toCharArray()) {
+                // 비교하여 같은 숫자인 경우 받은 숫자의 인덱스 하나 증가
+                if(c == array[i])
+                    i++;
+
+                // 받은 숫자가 마지막 수인 경우 반복문 종료
+                if(i == array.length)
+                    break;
+            }
+
+            // 비교할 숫자 증가
+            cur++;
+        }
+
+        System.out.println(cur - 1);
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 1515: 수 이어 쓰기](https://www.acmicpc.net/problem/1515)
<br>

## 📱 스크린샷
<img width="737" alt="image" src="https://github.com/user-attachments/assets/c33d6688-7c1c-4aff-9bbd-bf800dccf811">
<br>

## 📝 리뷰 내용
구현 방법
비교할 수: 제공 숫자의 첫번째부터 시작
받은 숫자의 인덱스: 0부터 시작

1. 만약 비교할 수(== 제공 숫자의 첫번째 수)가 0인 경우 1로 바꿔주기
2. 받은 숫자 현재 인덱스의 수와 비교할 수의 왼쪽부터 비교 합니다. 만약 둘이 같다면 받은 숫자의 인덱스를 하나 증가 시킵니다. 비교할 수의 마지막 자리수까지 반복.(만약 받은 숫자의 인덱스가 받은 숫자의 총 자리수와 같으면 반복 종료 합니다) 
3. 비교할 숫자를 하나 증가 하고 2번부터 다시 시작합니다.

처음에 1번 조건을 넣지 않아서 0을 입력한 경우 10이 나와야하는데 0이 나와서 틀렸습니다. 이 조건이 필요한 이유는 비교할 수는 1부터 시작한다는 문제 조건이 있기 때문입니다.

느낀점
항상 느끼는 거지만 놓친 부분을 찾는 과정이 너무 어렵습니다. 이런 상황을 해결할 방법은 결국은 문제와 내가 구현한 코드를 함께 보면서 찾아내는 것 입니다. 화이팅


