### PR TITLE
BOJ 17485: 진우의 달 여행 (Large)

### DIFF
--- a/limsubin/baekjoon/boj17485.py
+++ b/limsubin/baekjoon/boj17485.py
@@ -1,0 +1,24 @@
+# BOJ 17485: 진우의 달 여행 (Large)
+# https://www.acmicpc.net/problem/17485
+
+import sys
+
+def input():
+    return sys.stdin.readline().strip()
+
+n, m = map(int, input().split())
+space = [list(map(int, input().split())) for _ in range(n)]
+
+# 편리한 계산을 위해 양 옆으로 float('INF') 값 넣어줌!
+result = [[[float('INF')] + [space[i][j] for j in range(m)] + [float('INF')] for i in range(n)] for _ in range(3)]
+for i in range(1, n):
+    for j in range(1, m+1):
+        # 왼쪽으로 가는 대각선
+        result[0][i][j] += min(result[1][i-1][j], result[2][i-1][j-1])
+        # 아래쪽
+        result[1][i][j] += min(result[0][i-1][j+1], result[2][i-1][j-1])
+        # 오른쪽으로 가는 대각선
+        result[2][i][j] += min(result[0][i-1][j+1], result[1][i-1][j])
+
+answer = min(min(result[0][-1][1:m+1]), min(result[1][-1][1:m+1]), min(result[2][-1][1:m+1]))
+print(answer)


### PR DESCRIPTION
## 💡 문제
BOJ 17485: 진우의 달 여행 (Large)
<br>

## 📱 스크린샷
![image](https://github.com/user-attachments/assets/a26ed6a2-a78e-416d-9a64-40968d059f68)
<br>

## 📝 리뷰 내용
DP로 풀었습니다.
파이프 옮기기 문제가 생각 나서 쉽게 풀었어요.

크기가 3 * n * m+2 인 3차원 배열 만들어줍니다.
3차원 배열을 선언해준 이유는 각 방향의 최솟값을 구하기 위함이고,
열의 크기가 m+2인 이유는 인덱스 에러가 나지 않게 계산 편하게 해주려고 양 옆으로 max 값을 하나씩 더 넣어서 확장해줬습니다.

그리고 차례대로 계산해주는데 같은 방향을 연속으로 갈 수 없으니
↙️ : 앞 단계 ⬇️, ↘️ 의 최솟값
⬇️ : 앞 단계 ↙️, ↘️ 의 최솟값
↘️ : 앞 단계 ↙️, ⬇️ 의 최솟값
을 합산해주면 됩니다.
그렇게 해서 마지막에 최종 최솟값을 출력했어요.

아마 Small 문제는 bfs로도 풀리지 않을까 싶습니당.