### PR TITLE
BOJ 17485: 진우의 달 여행 (Large)

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj17485.java
+++ b/kimdaeyeong/src/baekjoon/Boj17485.java
@@ -1,0 +1,68 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 17485
+ * 진우의 달 여행 (Large)
+ * 골드5
+ * https://www.acmicpc.net/problem/17485
+ */
+public class Boj17485 {
+
+    public static void main(String[] agrs) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken()); // 행
+        int M = Integer.parseInt(st.nextToken()); // 열
+
+        int[][] array = new int[N][M];
+        int[][][] dp = new int[N][M][3]; // 행, 열, 앞으로 갈 방향(왼쪽 대각, 아래, 오른쪽 대각)
+        for(int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j = 0; j < M; j++) {
+                array[i][j] = Integer.parseInt(st.nextToken());
+                for(int d = 0; d < 3; d++)
+                    dp[i][j][d] = 1000001;
+            }
+        }
+
+        for(int j = 0; j < M; j++) {
+            for(int d = 0; d < 3; d++) {
+                dp[0][j][d] = array[0][j];
+            }
+        }
+
+        for(int i = 1; i < N; i++) {
+            for(int j = 0; j < M; j++) {
+                if(j - 1 >= 0)
+                    dp[i][j][0] = array[i][j] + Math.min(dp[i - 1][j][1], dp[i - 1][j - 1][2]);
+                else
+                    dp[i][j][0] = array[i][j] + dp[i - 1][j][1];
+
+                if(j - 1 >= 0 && j + 1 < M)
+                    dp[i][j][1] = array[i][j] + Math.min(dp[i - 1][j + 1][0], dp[i - 1][j - 1][2]);
+                else if(j - 1 >= 0 && j + 1 >= M)
+                    dp[i][j][1] = array[i][j] + dp[i - 1][j - 1][2];
+                else if(j - 1 < 0 && j + 1 < M)
+                    dp[i][j][1] = array[i][j] + dp[i - 1][j + 1][0];
+
+                if(j + 1 < M)
+                    dp[i][j][2] = array[i][j] + Math.min(dp[i - 1][j][1], dp[i - 1][j + 1][0]);
+                else
+                    dp[i][j][2] = array[i][j] + dp[i - 1][j][1];
+            }
+        }
+
+        int min = Integer.MAX_VALUE;
+        for(int j = 0; j < M; j++) {
+            for(int d = 0; d < 3; d++) {
+                min = Math.min(min, dp[N -1][j][d]);
+            }
+        }
+
+        System.out.println(min);
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 17485: 진우의 달 여행 (Large)](https://www.acmicpc.net/problem/17485)
<br>

## 📱 스크린샷
<img width="955" alt="image" src="https://github.com/user-attachments/assets/1b6aad4e-457d-4ff4-bc65-a4e16498c92f">
<br>

## 📝 리뷰 내용
일정한 패턴의 방향, 이전의 값으로 다음 값을 계산 이 두가지를 캐치하고 dp 문제구나 했습니다. 
그런데 잠깐! 전의 값이 똑같은 경우에 판단이 안된다고 생각을 하고 결국에는 완전 탐색을 해야겠다. 라고 생각 했습니다.

완전탐색을 하기 전에 메모리가 어느정도 먹을지 판단했습니다. 일단 행과 열 1000 * 1000, 방향 3방향, int[비용, x좌표, y좌표, 방향]으로 4 * 4 byte 모두 곱하면 48MB가 나옵니다. 문제에서 제한이 256MB 충분하겠다 생각했습니다. 그리하여 bfs와 큐를 사용하여 구현했는데 왠걸 메모리 초과가 떴습니다. 대체왜!!!!

다시 찬찬히 한번 생각해봤습니다.
생각해보니 최악의 경우 1000 * 1000 * 3의 개수가 큐에 들어가는것이 아니고 3^(1000 * 1000)의 데이터가 들어갈 확률이 있었던 것이였습니다. 단순히 한 노드당 3방향이 생기는 것이 아니고 한 노드당 3 방향이 생기고 그 3방향당 또 3방향으로 갈라지기 때문입니다.

그럼 다시 처음으로 돌아와서 dp로 전의 값이 똑같은 경우에 판단을 어떻게 해야 하나 고민했습니다. 생각해보니 방향에 따른 값까지 저장을 하면 해결되는 문제 였습니다. 

따라서 dp[행][열][방향] 3차원으로 만들어서 방향에 대한 최소값을 비교하면서 업데이트 하는 식으로 구현하니 해결되었습니다.

느낀점
갈길이 멀지만 갈 수 있다! 입니다.
