### PR TITLE
BOJ 3584: 가장 가까운 공통 조상

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj3584.java
+++ b/kimdaeyeong/src/baekjoon/Boj3584.java
@@ -1,0 +1,105 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 3584
+ * 가장 가까운 공통 조상
+ * 골드4
+ * https://www.acmicpc.net/problem/3584
+ */
+public class Boj3584 {
+
+    static int N; // 노드의 수
+    static List<Integer>[] g; // 그래프
+    static int T1; // 공통 조상을 구해야하는 값
+    static int T2; // 공통 조상을 구해야하는 값
+    static List<Integer>[] T1Child; // 깊이에 따른 자신의 조상
+    static List<Integer>[] T2Child; // 깊이에 따른 자신의 조상
+
+    public static void main(String[] agrs) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine()); // 테스트 케이스
+
+        for(int t = 0; t < T; t++) {
+            N = Integer.parseInt(br.readLine());
+            g = new ArrayList[N + 1];
+            T1Child = new ArrayList[N];
+            T2Child = new ArrayList[N];
+
+            // 초기화
+            for(int i = 1; i < N + 1; i++)
+                g[i] = new ArrayList<>();
+
+            // 초기화
+            for(int i = 0; i < N; i++) {
+                T1Child[i] = new ArrayList<>();
+                T2Child[i] = new ArrayList<>();
+            }
+
+            for(int i = 1; i < N; i++) {
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                g[b].add(a); // 자식에서 부모를 갈 수 있도록 설정, 조상을 구하는 거니까
+            }
+
+            st = new StringTokenizer(br.readLine());
+            T1 = Integer.parseInt(st.nextToken());
+            T2 = Integer.parseInt(st.nextToken());
+
+            dfs(T1, 0, new boolean[N + 1], T1Child);
+            dfs(T2, 0, new boolean[N + 1], T2Child);
+
+            sb.append(findMin()).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    // 조상 구하기
+    static void dfs(int cur, int d, boolean[] visited, List<Integer>[] TChild) {
+
+        visited[cur] = true;
+        TChild[d].add(cur); // d 깊이에서의 조상 노드 저장
+
+        for(int i = 0; i < g[cur].size(); i++) {
+            int next = g[cur].get(i);
+
+            if(visited[next])
+                continue;
+
+            dfs(next, d + 1, visited, TChild);
+        }
+    }
+
+    // 두 노드의 가장 가까운 공통 조상 구하기
+    static int findMin() {
+
+        int min = Integer.MAX_VALUE; // 깊이 합의 최소값
+        int answer = -1; // 공통 조상
+        for(int i = 0; i < N; i++) {
+            for(int j = 0; j < T1Child[i].size(); j++) {
+                int c1 = T1Child[i].get(j); // T1의 조상
+
+                for(int x = 0; x < N; x++) {
+                    for(int y = 0; y < T2Child[x].size(); y++) {
+                        int c2 = T2Child[x].get(y); // T2의 조상
+
+                        if(c1 == c2) {
+                            if(i + x < min) {
+                                min = i + x;
+                                answer = c1;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return answer;
+    }
+}

--- a/kimdaeyeong/src/baekjoon/Boj3584LCA.java
+++ b/kimdaeyeong/src/baekjoon/Boj3584LCA.java
@@ -1,0 +1,67 @@
+package baekjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * 백준 3584
+ * 가장 가까운 공통 조상
+ * LCA(Lowest Common Ancestor) 알고리즘 적용
+ * 골드4
+ * https://www.acmicpc.net/problem/3584
+ */
+public class Boj3584LCA {
+
+    static int N; // 노드의 수
+    static int[] parent; // 부모 자식 배열
+
+    public static void main(String[] agrs) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine()); // 테스트 케이스
+
+        for(int t = 0; t < T; t++) {
+            N = Integer.parseInt(br.readLine()); // 노드의 수
+            parent = new int[N + 1]; // 부모 자식 배열
+
+            for(int i = 1; i < N; i++) {
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+               parent[b] = a; // 자식에서 부모를 갈 수 있도록 설정, 조상을 구하는 거니까
+            }
+
+            st = new StringTokenizer(br.readLine());
+            int T1 = Integer.parseInt(st.nextToken());
+            int T2 = Integer.parseInt(st.nextToken());
+
+            sb.append(solution(T1, T2)).append("\n");
+        }
+        System.out.println(sb);
+    }
+
+    static int solution(int x, int y) {
+        boolean[] visited = new boolean[N + 1];
+
+        // x의 조상들 방문
+        while(x > 0) {
+            visited[x] = true;
+            x = parent[x];
+        }
+
+        // y의 조상들 방문하면서 x의 조상과 겹치는 경우가 최소 공통 조상
+        while(y > 0) {
+            if(visited[y])
+                return y;
+
+            y = parent[y];
+        }
+        return -1;
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 3584: 가장 가까운 공통 조상](https://www.acmicpc.net/problem/3584)
<br>

## 📱 스크린샷
<img width="965" alt="image" src="https://github.com/user-attachments/assets/a65b80ad-e564-4057-8f10-c6395b305dcf">
<br>

## 📝 리뷰 내용
**구현 아이디어1**
처음에 각 노드별로 자신의 자식들 리스트를 전부 구해서 원하는 노드 두개가 존재하는 경우를 골라 가장 가까운 조상을 구하는 방식을 생각했다. 하지만 이 방법은 모든 노드에 대한 자식리스트를 구하는 과정에서 많은 중복이 발생할 것 같았다. 

**구현 아이디어2**
공통 조상을 구하려 하는 두 노드의 부모를 깊이에 따라 미리 구해 놓고, 구한 값들을 비교하며 가장 가까운 공통 조상을 구하기로 했다.

1. 부모, 자식 방향 그래프를 List<Integer>[] g 형태로 만든다.
   1) 주의할 점은 현재 문제에서 자식 노드에서 부모 노드를 찾기 때문에 **자식 -> 부모** 형태로 저장하는 것이 좋다.
2. dfs를 통해 두 자식 노드들의 부모들을 List<Integer>[] 형태로 저장한다. 이때 배열 인덱스는 깊이가 되고, 값들은 부모 노드들이 된다.
3. 두개의 깊이에 따른 부모 노드들의 배열 리스트를 비교하며 가장 가까운 공통 조상을 찾는다.

**LCA**
하지만 두번째 구현 아이디어 또한 dfs로 두 노드의 부모들을 구한다. 이 경우도 두 노드간에 겹치는 노드들이 있을 것이고, 이는 중복 계산이 될 것이다. 또한 현재 문제를 유니온 파인드로 풀 수 있지 않을까? 라는 생각에 추가 공부를 했다. 찾아보니 LCA(Lowest Common Ancestor) 알고리즘을 적용하여 풀 수 있었다.

구현 방법
1. 노드 각각의 부모 자식 관계를 parent[자식] = 부모 배열로 저장한다.
2. 두 노드중 한 노드의 부모들을 방문하면서 visited[] 배열에 방문 체크를 한다. (깊이가 점점 깊어짐)
3. 나머지 노드 또한 부모들을 방문하면서 visited[] 배열에 체크한다. 이때 이미 방문한 적이 있는 노드는 첫번째 노드의 조상이기 때문에 이것이 가장 가까운 공통 조상이 된다.

느낀점
최적화 방법을 생각하는게 많은 도움이 된다. 역시 똑똑한 사람들이 너무 많고 신기하다.
 
