### PR TITLE
PG 131114: 경기도에 위치한 식품창고 목록 출력하기

### DIFF
--- a/limsubin/sql/pg131114.sql
+++ b/limsubin/sql/pg131114.sql
@@ -1,0 +1,10 @@
+# PG 131114: 경기도에 위치한 식품창고 목록 출력하기
+# https://school.programmers.co.kr/learn/courses/30/lessons/131114
+
+select warehouse_id, warehouse_name, address,
+        case when freezer_yn is null then 'N'
+                else freezer_yn
+                end as freezer_yn
+from food_warehouse
+where address like "경기도%"
+order by warehouse_id;


### PR DESCRIPTION
## 💡 문제
PG 131114: 경기도에 위치한 식품창고 목록 출력하기
<br>

## 📱 스크린샷
![image](https://github.com/user-attachments/assets/0c23a57d-2760-42c7-848a-9c9c8fab3313)
<br>

## 📝 리뷰 내용
null인 데이터에 대해 처리하는 부분은 case 사용했고,
경기도 데이터에 대해 처리하는 부분은 와일드카드 문자와 함께 like 사용했습니다.
