### PR TITLE
BOJ 2036: 수열의 점수

### DIFF
--- a/limsubin/baekjoon/boj2036.py
+++ b/limsubin/baekjoon/boj2036.py
@@ -1,0 +1,41 @@
+# BOJ 2036: 수열의 점수
+# https://www.acmicpc.net/problem/2036
+
+import sys
+import heapq
+
+def input():
+    return sys.stdin.readline().strip()
+
+def sum(heap, flag):
+    result = 0
+
+    while len(heap) >= 2:
+        # 2개씩 꺼내서
+        a = heapq.heappop(heap)
+        b = heapq.heappop(heap)
+        # 곱하기!
+        result += a * b
+
+    # 끝에 하나 남았을 때
+    if heap:
+        return result + flag * heapq.heappop(heap)
+
+    return result
+
+plus = [] # 양수
+minus = [] # 음수
+answer = 0
+
+n = int(input())
+for _ in range(n):
+    i = int(input())
+    if i <= 0:
+        heapq.heappush(minus, i)
+    elif i == 1:
+        answer += 1 # 1은 다른 수랑 곱하는 것보다 따로 더하는게 더 크다.
+    else:
+        heapq.heappush(plus, -i)
+
+answer += sum(plus, -1) + sum(minus, 1)
+print(answer)


### PR DESCRIPTION
## 💡 문제
BOJ 2036: 수열의 점수
<br>

## 📱 스크린샷
![image](https://github.com/user-attachments/assets/395c69a8-d2b6-486c-b429-7b088f39576f)
<br>

## 📝 리뷰 내용
우선순위 큐를 이용하여 풀었습니다.

양수끼리(내림차순), 음수끼리(오름차순), 1만 모읍니다.
1을 따로 모으는 이유는 1은 다른 수와 곱하는 것보다 더하는게 더 이득이기 때문입니다.
1은 어차피 다 더할 거기 때문에 따로 우선순위 큐 안 쓰고 바로 answer++ 해줬습니다.
어쨌든 다 모았으면 큐에서 두개씩 꺼내서 곱해서 더해주면 됩니다.
홀수 개로 남았다면 마지막에 하나 남으니까 그건 따로 혼자 더해줍니당.

처음에 1을 따로 고려 안 해서 틀렸습니다. 하하
