### PR TITLE
BOJ 2036: 수열의 점수

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj2036.java
+++ b/kimdaeyeong/src/baekjoon/Boj2036.java
@@ -1,0 +1,58 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * 백준 2036
+ * 수열의 점수
+ * 골드4
+ * https://www.acmicpc.net/problem/2036
+ */
+public class Boj2036 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine()); // 정수의 개수
+        List<Long> plus = new ArrayList<>();
+        Long answer = 0L;
+        boolean zero = false;
+        List<Long> minus = new ArrayList<>();
+        for(int i = 0; i < n; i++) {
+            long num = Long.parseLong(br.readLine());
+            if(num > 1L)
+                plus.add(num);
+            else if(num < 0)
+                minus.add(num);
+            else if(num == 1L)
+                answer++;
+            else
+                zero = true;
+        }
+
+        Collections.sort(plus);
+        Collections.sort(minus);
+
+        int plusSize = plus.size();
+        int minusSize = minus.size();
+
+        for(int i = plusSize - 1; i > 0; i-=2) {
+            answer += plus.get(i) * plus.get(i - 1);
+        }
+
+        if(plusSize % 2 != 0)
+            answer += plus.get(0);
+
+
+        for(int i = 0; i < minusSize - 1; i+=2) {
+            answer += minus.get(i) * minus.get(i + 1);
+        }
+
+        if(minusSize % 2 != 0 && !zero) {
+            answer += minus.get(minusSize - 1);
+        }
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 2036: 수열의 점수](https://www.acmicpc.net/problem/2036)
<br>

## 📱 스크린샷
<img width="950" alt="image" src="https://github.com/user-attachments/assets/fa328d71-8619-4660-a9f9-3b113dd05cd9">
<br>

## 📝 리뷰 내용
실패 이유 1
1이 여러개 있는 경우는 두개씩 곱하는거 보다 무조건 더하는게 이득인데, 그 부분을 놓쳤습니다.

실패 이유 2
음의 수열의 내림차순은 -9 -8 -7 순서인데 -7-8 -9라고 잘못 생각했습니다.

**구현 방법**
1. 1보다 큰 수들의 수열, 음수로 이루어진 수열, 0의 존재 여부, 1의 개수 데이터를 저장합니다.
2. 1보다 큰 수들의 수열, 음수로 이루어진 수열 절대값이 큰 순서대로 2개씩 곱하며 더했습니다.
3. 만약 1보다 큰 수들의 수열의 개수가 홀수인 경우 마지막 짝이 없는 친구는 더해줬습니다.
4. 만약 음수로 이루어진 수열의 개수가 홀수인 경우, 0이 존재한다면 곱하고, 아니면 제일 큰 음수를 남겨서 더해줬습니다.

여기서 0의 개수는 중요하지 않고 존재여부만 중요합니다. 이유는 수많은 0은 덧셈을 하는게 제일 이득이고, 하나의 0만 음수를 처리할 때 사용되기 때문입니다.

**느낀점**
문제가 쉽다고 생각했는데 놓치는 부분이 있었습니다. 다양한 input data를 생각할 수 있는 능력을 길러야 겠습니다.
