### PR TITLE
BOJ 12886: 돌 그룹

### DIFF
--- a/limsubin/baekjoon/boj12886.py
+++ b/limsubin/baekjoon/boj12886.py
@@ -1,0 +1,54 @@
+# BOJ 12886: 돌 그룹
+# https://www.acmicpc.net/problem/12886
+
+from collections import deque
+
+def bfs(a, b, c):
+    if a == b == c:
+        return 1
+
+    # 전체 개수는 변하지 않는다!
+    total = a + b + c
+
+    x = min(a, b, c)
+    y = max(a, b, c)
+
+    queue = deque()
+    queue.append([x, y, total-x-y]) # a, b, c
+    visited[x][y] = True
+
+    while queue:
+        a, b, c = queue.popleft()
+
+        # 2개 고르기
+        for x, y in (a, b), (b, c), (a, c):
+            if x == y:
+                continue
+
+            # 큰 쪽은 빼주고, 작은 쪽은 더해주기
+            if x > y:
+                x -= y
+                y += y
+            else:
+                y -= x
+                x += x
+            c = total - x - y
+
+            if x == y == c:
+                return 1
+
+            # 어차피 전체 개수는 고정이기 때문에 최소, 최대를 넣어 중복을 제거
+            xx = min(x, y, c)
+            yy = max(x, y, c)
+
+            if visited[xx][yy]:
+                continue
+
+            queue.append([xx, yy, c])
+            visited[xx][yy] = True
+
+    return 0
+
+a, b, c = map(int, input().split())
+visited = [[False] * (a + b + c) for _ in range(a + b + c)]
+print(bfs(a, b, c))


### PR DESCRIPTION
## 💡 문제
BOJ 12886: 돌 그룹
<br>

## 📱 스크린샷
![image](https://github.com/user-attachments/assets/ca377ac5-6b24-4042-8d67-509cd529535c)
<br>

## 📝 리뷰 내용
질문 게시판 참고해서 풀었습니다 🥹

처음엔 BFS로 모든 경우의 수(?)를 다 보았고, 중복이 많아 시간 초과가 난 것 같습니다.
그 후 중복을 줄여보겠다고 큐에서 꺼내서 제일 작은 것과 제일 큰 것만 뽑아서 연산하려다가.. 그냥 아예 틀렸습니다. 하하

어떻게 하면 시간을 줄일 수 있을지 모르겠어서 결국 질문 게시판을 봤어요.
우선 `돌의 총 개수는 불변`이라는 사실을 깨달았습니다. 계속 한 쪽에 x를 더하고 한 쪽에 x를 빼니까요.
그리고 BFS를 돌리는데 x, y를 뽑아 `연산을 끝낸 후 최솟값과 최댓값을 찾아 방문 체크`를 합니다.
이 아이디어가 중복을 줄이는 핵심이었습니다!!! 시간이 10배는 줄었네요

시간 최적화하는 방법 생각하는게 너무 어려운 것 같습니다 ㅠㅡㅠ