### PR TITLE
BOJ 12886: 돌 그룹

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj12886.java
+++ b/kimdaeyeong/src/baekjoon/Boj12886.java
@@ -18,11 +18,12 @@ public class Boj12886 {
         int B = Integer.parseInt(st.nextToken());
         int C = Integer.parseInt(st.nextToken());
 
-        boolean[][] visited = new boolean[1501][1501];
         int sum = A + B + C;
         int answer = 0;
+        boolean[][] visited = new boolean[1501][1501];
         visited[A][B] = true;
         visited[B][A] = true;
+
         if(sum % 3 == 0 && dfs(sum, A, B, visited)) {
             answer = 1;
         }
@@ -40,15 +41,23 @@ public class Boj12886 {
         int[] array = {a, b, c};
         boolean checked = false;
 
-        for(int i = 0; i < 3; i++) {
+        for(int i = 0; i < 2; i++) {
             for(int j = i + 1; j < 3; j++) {
                 if(array[i] != array[j]) {
-                    int na = array[i] > array[j] ? array[i] - array[j] : array[i] * 2;
-                    int nb = array[i] < array[j] ? array[j] - array[i] : array[j] * 2;
+                    int na = array[i] > array[j] ? array[i] - array[j] : array[i] << 1;
+                    int nb = array[i] < array[j] ? array[j] - array[i] : array[j] << 1;
 
                     if(!visited[na][nb]) {
+                        int nc = sum  - na - nb;
+
                         visited[na][nb] = true;
                         visited[nb][na] = true;
+
+                        visited[na][nc] = true;
+                        visited[nc][na] = true;
+
+                        visited[nc][nb] = true;
+                        visited[nb][nc] = true;
 
                         checked = dfs(sum, na, nb, visited);
                     }

--- a/kimdaeyeong/src/baekjoon/Boj12886.java
+++ b/kimdaeyeong/src/baekjoon/Boj12886.java
@@ -1,0 +1,64 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * 백준 12886
+ * 돌 그룹
+ * 골드4
+ * https://www.acmicpc.net/problem/12886
+ */
+public class Boj12886 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int A = Integer.parseInt(st.nextToken());
+        int B = Integer.parseInt(st.nextToken());
+        int C = Integer.parseInt(st.nextToken());
+
+        boolean[][] visited = new boolean[1501][1501];
+        int sum = A + B + C;
+        int answer = 0;
+        visited[A][B] = true;
+        visited[B][A] = true;
+        if(sum % 3 == 0 && dfs(sum, A, B, visited)) {
+            answer = 1;
+        }
+
+        System.out.println(answer);
+    }
+
+    public static boolean dfs(int sum, int a, int b, boolean[][] visited) {
+        int c = sum - a - b;
+
+        if(a == b && b == c) {
+            return true;
+        }
+
+        int[] array = {a, b, c};
+        boolean checked = false;
+
+        for(int i = 0; i < 3; i++) {
+            for(int j = i + 1; j < 3; j++) {
+                if(array[i] != array[j]) {
+                    int na = array[i] > array[j] ? array[i] - array[j] : array[i] * 2;
+                    int nb = array[i] < array[j] ? array[j] - array[i] : array[j] * 2;
+
+                    if(!visited[na][nb]) {
+                        visited[na][nb] = true;
+                        visited[nb][na] = true;
+
+                        checked = dfs(sum, na, nb, visited);
+                    }
+
+                    if(checked)
+                        return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/kimdaeyeong/src/baekjoon/Boj12886SlowVer.java
+++ b/kimdaeyeong/src/baekjoon/Boj12886SlowVer.java
@@ -1,0 +1,61 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * 백준 12886
+ * 돌 그룹
+ * 골드4
+ * https://www.acmicpc.net/problem/12886
+ */
+public class Boj12886SlowVer {
+
+    static int answer = 0;
+    static Set<String> visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int A = Integer.parseInt(st.nextToken());
+        int B = Integer.parseInt(st.nextToken());
+        int C = Integer.parseInt(st.nextToken());
+
+        visited = new HashSet<>();
+        visited.add(A + "" + B + C);
+        dfs(A, B, C);
+        System.out.println(answer);
+    }
+
+    public static void dfs(int a, int b, int c) {
+
+        if(answer == 1)
+            return;
+
+        if(a == b && b == c) {
+            answer = 1;
+            return;
+        }
+
+        int[] array = {a, b, c};
+        Arrays.sort(array);
+        String s1 = (array[0] + array[0]) + "" + (array[1] - array[0]) + array[2];
+        if(!visited.contains(s1)) {
+            visited.add(s1);
+            dfs(array[0] + array[0], array[1] - array[0], array[2]);
+        }
+
+        String s2 = (array[0] + array[0]) + "" + array[1] + (array[2] - array[0]);
+        if(!visited.contains(s2)) {
+            visited.add(s2);
+            dfs(array[0] + array[0], array[1], array[2] - array[0]);
+        }
+
+        String s3 = array[0] + "" + (array[1] + array[1]) + (array[2] - array[1]);
+        if(!visited.contains(s3)) {
+            visited.add(s3);
+            dfs(array[0], array[1] + array[1], array[2] - array[1]);
+        }
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 12886: 돌 그룹](https://www.acmicpc.net/problem/12886)
<br>

## 📱 스크린샷
<img width="950" alt="image" src="https://github.com/user-attachments/assets/29bd65c0-a493-4bb9-8685-cb2b7d4bb941">
<br>

## 📝 리뷰 내용
**느린 구현 방식**
dfs 이용해서 모든 경우에 대해 조건에 만족하는 경우를 찾으려고 했습니다. 현재 문제에서는 어차피 모든 경우를 비교해서 답을 구하므로 dfs, bfs 차이가 크게 없다고 판단했습니다. 하지만 시간 초과가 났습니다.

이유는 서로 다른 숫자만 골라서 문제에서 원하는 계산을 해줘야 하는데 같은 숫자도 고려했습니다. 
또다른 이유는 방문 처리 과정에서 중복 문제가 생깁니다. 제가 생각한 방문 방식은 모든 숫자를 문자열로 변환하여 set 자료구조에 넣는 방식이였습니다. 이 경우 8, 10, 9 형태는 8109로 저장이 됩니다.  따라서 10, 8, 9도 같은 경우이지만 다른 경우로 판단합니다.

첫번째 문제 해결 방법은
두 숫자를 골랐을때 같은 숫자인지 판단하면 됩니다.

두번재 문제를 해결하는 방법은
세 숫자를 넣을 배열을 만들어 sort 하는 과정을 넣고, 모든 숫자에 대해 문자열로 변환 후 set 자료구조에 넣도록 했습니다.

이런 방식으로 구현하면 느리게 통과가 됩니다. 하지만 느린 이유는 각 순간마다 소팅과정 nlogn이 들어가기 때문입니다. 메모리 또한 많이 먹는데 각 순간마다 배열을 만들기고 하고, set 자료구조에 많은 데이터 값이 들어가기 때문입니다.

이 방식은 위험할 수도 있습니다. 예시로 33, 33, 33 숫자를 넣었다고 가정한다면 set 자료구조에는 333333으로 들어가게 될 텐데 이는 333, 3, 33으로 해석될 여지가 있습니다. 따라서 333, 3, 33가 먼저 나온다면 방문처리가 333333으로 되어 추후에 33 33 33이 되었을 때 이를 방문하지 못하게 되어 답이 나오지 않을 경우가 생기게 됩니다.

이 문제 특성상 이런 상황을 만족하는 경우가 나오지 않을 수도 있습니다. 또한 세 숫자 사이에 ,같은 표시를 통해 해결할 수 있습니다. 하지만 이 구현 방식은 너무 느립니다.

**빠른 구현 방식**
여기서 다른 두 숫자를 골라 b > a인 경우 a + a, b - a 해준다고 했습니다. 이게 무슨 뜻이냐면 고른 두 숫자를 합하면 위의 계산을 하기 전이나 후나 합이 같다는 뜻입니다. (a + b, a + a + (b - a)) 그래서 두 숫자만 알면 나머지 한 숫자는 자동으로 알 수 있습니다. 따라서 방문 체크를 visited[a][b] 형태로 해주면 됩니다. 이렇게 한다면 메모리를 많이 잡아 먹지도 않고, 각 재귀마다 소팅 과정도 생략되기 때문에 시간이 빨라집니다.

**느낀점**
문제의 조건에서 숨은 뜻을 찾는게 어렵네요. 못찾아서 분합니다. 

**추가 구현**
리뷰 내용 반영해서 코드 수정 했습니다. 속도가 196ms -> 169ms 까지 내렸네요. @tddudwns1  감사합니다.
1. dfs 내 포문 범위 변경
2. 곱하기 2 연산 비트 연산자로 변경
3. 방문 체크 추가
    a. 전 코드 : a,b/b,a
    b. 리펙토링 : a,b/b,a/a,c/c,a/c,b/b,c

추가로 visited 배열 if문 안에 넣는건 해보니 더 느려지더라고요. 아래 리뷰 답글 참고해 보세요.

