### PR TITLE
BOJ 2240: 자두나무

### DIFF
--- a/limsubin/baekjoon/boj2240.py
+++ b/limsubin/baekjoon/boj2240.py
@@ -1,0 +1,27 @@
+# BOJ 2240: 자두나무
+# https://www.acmicpc.net/problem/2240
+
+t, w = map(int, input().split())
+tree = [0] + [int(input()) for _ in range(t)]
+
+result = [[0] * (t+1) for _ in range(w+1)]
+
+# 초기값 (이동 X)
+for j in range(1, t+1):
+    result[0][j] = result[0][j-1] + tree[j] % 2
+
+for i in range(1, w+1):
+    for j in range(1, t+1):
+        result[i][j] = max(result[i][j-1], result[i-1][j-1])
+
+        # 현재 위치 (2의 배수 만큼 이동했으면 1, 아니면 2)
+        cur = 1 if i % 2 == 0 else 2
+        # 현재 위치에서 자두가 떨어지고 있는 경우
+        if tree[j] == cur:
+            result[i][j] += 1
+
+answer = 0
+for i in range(w+1):
+    answer = max(answer, result[i][-1])
+
+print(answer)


### PR DESCRIPTION
## 💡 문제
BOJ 2240: 자두나무
<br>

## 📱 스크린샷
![image](https://github.com/user-attachments/assets/e51a471c-fbd3-4713-9515-09f52706b208)
<br>

## 📝 리뷰 내용
DP로 풀었습니다.

<img width="300" alt="image" src="https://github.com/user-attachments/assets/ebe42793-d1cd-47e3-ade1-b8b144f887ae">

[w+1][t+1] 배열을 만듭니다. 행의 인덱스는 이동을 몇 번 하느냐를 의미하고, 열의 인덱스는 현재 몇 초가 지났는지를 의미합니다.

```python
for j in range(1, t+1):
    result[0][j] = result[0][j-1] + tree[j] % 2
```
0행은 초기값이에요. (이동을 한 번도 안 하니까) 트리 값이 1이면 +1 해주면 됩니다.

```python
result[i][j] = max(result[i][j-1], result[i-1][j-1])
```
result[i][j-1]는 바로 전 위치에서 이미 이동을 i번까지 마쳤을 때의 최댓값입니다.
result[i-1][j-1]는 바로 전 위치에서 이동을 i-1번 마쳤을 때의 최댓값입니다. 따라서 현재 위치로 오면 이동을 한 번 더 해서 i번 이동한게 되겠죠!

```python
cur = 1 if i % 2 == 0 else 2
if tree[j] == cur:
    result[i][j] += 1
```
그 후 현재 위치가 몇 번 트리에 있는지 찾아서 자두를 먹을 수 있는지 여부를 판단해주면 됩니다.
2의 배수만큼 움직였으면 초기 위치에 있을 것이고(1번 트리), 아니면 반대편에 있을 거예요. (2번 트리)
따라서 현재 위치와 자두가 떨어지는 위치가 같으면 +1 해주면 됩니당.

마지막에 최댓값 출력해주면 끝!