### PR TITLE
BOJ 2240: 자두나무

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj2240Ver1.java
+++ b/kimdaeyeong/src/baekjoon/Boj2240Ver1.java
@@ -1,0 +1,85 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 2240
+ * 자두나무
+ * 골드5
+ * https://www.acmicpc.net/problem/2240
+ */
+public class Boj2240Ver1 {
+
+    static class Info {
+        int treeLocation; // 나무 위치
+        int time; // 지속 시간
+
+        public Info(int treeLocation, int time) {
+            this.treeLocation = treeLocation;
+            this.time = time;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int T = Integer.parseInt(st.nextToken()); // 떨어지는 시간
+        int W = Integer.parseInt(st.nextToken()); // 최대 움직임 수
+
+        List<Info> infos = new ArrayList<>();
+        int cnt = 1;
+        int pre = Integer.parseInt(br.readLine());
+        infos.add(new Info(0, 0));
+        for(int i = 1; i < T; i++) {
+            int cur = Integer.parseInt(br.readLine()); // 나무 위치 1, 2
+            if(cur == pre) {
+                cnt++;
+            } else {
+                infos.add(new Info(pre, cnt));
+                cnt = 1;
+                pre = cur;
+            }
+        }
+        infos.add(new Info(pre, cnt));
+
+        int[][] dp = new int[infos.size()][W + 1];
+        for(int i = 1; i < infos.size(); i++) {
+            Info cur = infos.get(i);
+
+            for(int j = 0; j <= W; j++) {
+                // 안 움직일때
+                if(j == 0) {
+                    if(cur.treeLocation == 1) {
+                        dp[i][j] = dp[i - 1][j] + cur.time;
+                    } else {
+                        dp[i][j] = dp[i - 1][j];
+                    }
+                    continue;
+                }
+
+                // 움직일때
+                if(j % 2 == 0) {
+                    if(cur.treeLocation == 1) {
+                        dp[i][j] = Math.max(dp[i - 1][j] + cur.time, dp[i - 1][j - 1]);
+                    } else {
+                        dp[i][j] = Math.max(dp[i - 1][j - 1] + cur.time, dp[i - 1][j]);
+                    }
+                } else {
+                    if(cur.treeLocation == 2) {
+                        dp[i][j] = Math.max(dp[i - 1][j] + cur.time, dp[i - 1][j - 1]);
+                    } else {
+                        dp[i][j] = Math.max(dp[i - 1][j - 1] + cur.time, dp[i - 1][j]);
+                    }
+                }
+            }
+        }
+
+        int answer = 0;
+        for(int j = 0; j <= W; j++)
+            answer = Math.max(answer, dp[infos.size() - 1][j]);
+
+        System.out.println(answer);
+    }
+}

--- a/kimdaeyeong/src/baekjoon/Boj2240Ver2.java
+++ b/kimdaeyeong/src/baekjoon/Boj2240Ver2.java
@@ -1,0 +1,60 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 2240
+ * 자두나무
+ * 골드5
+ * https://www.acmicpc.net/problem/2240
+ */
+public class Boj2240Ver2 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int T = Integer.parseInt(st.nextToken()); // 떨어지는 시간
+        int W = Integer.parseInt(st.nextToken()); // 최대 움직임 수
+
+        int[][] dp = new int[T + 1][W + 1]; // 시간, 움직임 횟수
+        for(int i = 1; i <= T; i++) {
+            int cur = Integer.parseInt(br.readLine());
+
+            for(int j = 0; j <= W; j++) {
+                // 안 움직일때
+                if(j == 0) {
+                    if(cur == 1) {
+                        dp[i][j] = dp[i - 1][j] + 1;
+                    } else {
+                        dp[i][j] = dp[i - 1][j];
+                    }
+                    continue;
+                }
+
+                // 움직일때
+                if(j % 2 == 0) {
+                    if(cur == 1) {
+                        dp[i][j] = Math.max(dp[i - 1][j] + 1, dp[i - 1][j - 1]);
+                    } else {
+                        dp[i][j] = Math.max(dp[i - 1][j - 1] + 1, dp[i - 1][j]);
+                    }
+                } else {
+                    if(cur == 2) {
+                        dp[i][j] = Math.max(dp[i - 1][j] + 1, dp[i - 1][j - 1] );
+                    } else {
+                        dp[i][j] = Math.max(dp[i - 1][j - 1] + 1, dp[i - 1][j]);
+                    }
+                }
+            }
+        }
+
+        int answer = 0;
+        for(int i = 0; i <= W; i++) {
+            answer = Math.max(answer, dp[T][i]);
+        }
+
+        System.out.println(answer);
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 2240: 자두나무](https://www.acmicpc.net/problem/2240)
<br>

## 📱 스크린샷
<img width="951" alt="image" src="https://github.com/user-attachments/assets/9d3d9390-669d-41e8-aef7-91a27a22b09d">
<br>

## 📝 리뷰 내용
처음에 dfs를 이용한 완탐했습니다. 시간을 줄여보려고 나름대로 노력을 했습니다.
**했던 노력**
연속으로 들어온 자두의 위치를 하나로 뭉치는 작업을 선행했습니다. 예를 들어 1 1 1 2 2 1 인 경우 (1, 3), (2, 2), (1, 2) 이런식 입니다. 하지만 시간초과를 피해갈수 없었는데요. 이유는 간단합니다. 압축해도 원래 input data와 같은 경우가 있다는 점이죠. 예를 들어 1 2 1 2 12 1 2 ... 이런식으로 연속된 값이 없는 경우 입니다.

**스스로 생각한 부분**
자 그래서 이번에는 당황하지 않고 문제를 다시 읽었습니다. 음.. 가만보니 이녀석 dp의 냄세가 나더군요. 반복되는 규칙, 전의 값이 다음값에 영향을 주고 있었습니다. 
그럼 생각해야 하는 조건이 뭘까 생각해봤습니다. 지나가는 시간, 현재 위치와 떨어지는 자두 위치, 이동 횟수 였습니다. input data에서 떨어지는 위치를 주니 dp[시간][이동횟수]로 기억한다면 문제를 충분히 풀 수 있을것이라고 판단 했습니다. 하지만 딱 여기까지 생각하고 그 뒤론 잘 안풀렸습니다. 그래서 풀지 못하고 구글의 힘을 빌렸습니다.

**구글링**
제가 놓친 핵심은 바로 위치는 2가지 경우이기 때문에 이동 횟수가 짝수인 경우 1에 위치, 홀수인 경우 2에 위치 한다는 점이였습니다. 또한 제한 횟수 이내로 최대 자두 갯수를 다 저장해야 한다는 점 또한 중요했습니다. 예를 들어 현재 위치가 1이고 움직임 최대 수가 3인 경우를 가정하겠습니다. 이때 1에서 자두가 떨어지면 움직임 0만 생각하는게 아니라 0과 2 모두 생각하여 저장하고 있어야 한다는 점입니다. 이렇게 해야 1 -> 2 -> 1 인 경우도 생각 할 수 있기 때문입니다.

**두가지 풀이**
Ver1은 연속된 자리인 경우 압축하는 과정이 포함되어 있고, Ver2는 그렇지 않은 풀이입니다. 둘의 속도 차이는 크게 나지 않는데 압축한다고 해서 시간복잡도가 달라지지 않기 때문입니다.

**느낀점**
dp 문제라는걸 눈치채도 못풀었네요. 경험 부족이라고 생각이 되어 dp 관련 문제를 많이 접해볼 생각입니다.

