### PR TITLE
BOJ 18427: 함께 블록 쌓기

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj18427.java
+++ b/kimdaeyeong/src/baekjoon/Boj18427.java
@@ -32,17 +32,12 @@ public class Boj18427 {
             }
         }
 
-        for(int i = 0; i <= N; i++)
-            dp[i][0] = 1;
+        dp[0][0] = 1;
 
         for(int i = 1; i <= N; i++) {
-            for(int j = 1; j <= H; j++) {
-
-                // i번째가 h를 내는 경우
-                for(int h : l[i]) {
-                    if(j >= h) {
-                        dp[i][j] = (dp[i][j] + dp[i - 1][j - h]) % 10007;
-                    }
+            for(int h : l[i]) {
+                for(int j = h; j <= H; j++) {
+                    dp[i][j] = (dp[i][j] + dp[i - 1][j - h]) % 10007;
                 }
             }
         }

--- a/kimdaeyeong/src/baekjoon/Boj18427.java
+++ b/kimdaeyeong/src/baekjoon/Boj18427.java
@@ -26,6 +26,7 @@ public class Boj18427 {
         for(int i = 1; i <= N; i++) {
             st = new StringTokenizer(br.readLine());
             l[i] = new ArrayList<>();
+            l[i].add(0); // 아무것도 안내는 경우
             while(st.hasMoreTokens()) {
                 l[i].add(Integer.parseInt(st.nextToken()));
             }
@@ -36,7 +37,6 @@ public class Boj18427 {
 
         for(int i = 1; i <= N; i++) {
             for(int j = 1; j <= H; j++) {
-                dp[i][j] += dp[i - 1][j]; // i번째가 아무것도 안내는 경우
 
                 // i번째가 h를 내는 경우
                 for(int h : l[i]) {

--- a/kimdaeyeong/src/baekjoon/Boj18427.java
+++ b/kimdaeyeong/src/baekjoon/Boj18427.java
@@ -1,0 +1,53 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 18427
+ * 함께 블록 쌓기
+ * 골드4
+ * https://www.acmicpc.net/problem/18427
+ */
+public class Boj18427 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken()); // 학생수
+        int M = Integer.parseInt(st.nextToken()); // 블록 수
+        int H = Integer.parseInt(st.nextToken()); // 구하는 높이
+
+        int[][] dp = new int[N + 1][H + 1];
+
+        List<Integer>[] l = new ArrayList[N + 1];
+
+        for(int i = 1; i <= N; i++) {
+            st = new StringTokenizer(br.readLine());
+            l[i] = new ArrayList<>();
+            while(st.hasMoreTokens()) {
+                l[i].add(Integer.parseInt(st.nextToken()));
+            }
+        }
+
+        for(int i = 0; i <= N; i++)
+            dp[i][0] = 1;
+
+        for(int i = 1; i <= N; i++) {
+            for(int j = 1; j <= H; j++) {
+                dp[i][j] += dp[i - 1][j]; // i번째가 아무것도 안내는 경우
+
+                // i번째가 h를 내는 경우
+                for(int h : l[i]) {
+                    if(j >= h) {
+                        dp[i][j] = (dp[i][j] + dp[i - 1][j - h]) % 10007;
+                    }
+                }
+            }
+        }
+
+        System.out.println(dp[N][H]);
+    }
+
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 18427: 함께 블록 쌓기](https://www.acmicpc.net/problem/18427)
<br>

## 📱 스크린샷
<img width="953" alt="image" src="https://github.com/user-attachments/assets/9c9c78db-49ba-4437-8f08-68ee9494aead">
<br>

## 📝 리뷰 내용
문제에 나와있는 범위를 보고 완탐하면 시간초과가 날것이라고 예상했습니다. 추가로 반복되는 규칙과 전의 값을 이용해 새로운 값을 만드는 패턴을 보고 dp유형이라는 것도 눈치챘습니다. 하지만 방법이 떠오르지 않아서 완탐(dfs) + 이분탐색 방법이면 혹시 시간초과가 안나지 않을까? 라는 기대로 먼저 풀었습니다.

**완탐 + 이분탐색**
1. 학생별로 높이를 오름차순으로 정렬 합니다.
2. 이분탐색으로 현재 높이 이하의 값들로 dfs를 돌립니다.
하지만 이 방법은 각각의 학생마다 모든 경우의 수를 찾기 때문에 역시 시간초과가 났습니다.

하지만 도저히 방법을 몰라 힌트를 얻었습니다. 냅색 알고리즘을 적용하면 되는 문제라더군요(@limsubinn 힌트 감사합니다.)
**냅색 알고리즘 적용**
1. 학생수, 최대 높이의 이차원 배열을 만듭니다.
2. 학생별로 가지고 있는 높이 데이터를 저장합니다. 이때 학생이 아무것도 안내는 경우가 있으니 0도 함께 넣습니다.
3. 점화식 dp[i][j] += dp[i][h] + dp[i - 1][j - h]를 이용하여 값을 구합니다.

**dp[i][j] += dp[i][h] + dp[i - 1][j - h] 해석**
현재 학생이 낼 h와 이전에 (j - h)높이를 만들수 있는 모든 경우의 수를 더하면 지금까지의 j에 대한 모든 경우의 수가 나옵니다.