### PR TITLE
BOJ 3079: 입국심사

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj3079.java
+++ b/kimdaeyeong/src/baekjoon/Boj3079.java
@@ -41,7 +41,7 @@ public class Boj3079 {
 
             if(sum >= M) {
                 right = mid - 1;
-                answer = Math.min(answer, mid);
+                answer = mid;
             } else {
                 left = mid + 1;
             }

--- a/kimdaeyeong/src/baekjoon/Boj3079.java
+++ b/kimdaeyeong/src/baekjoon/Boj3079.java
@@ -1,0 +1,53 @@
+package baekjoon;
+
+import java.io.*;
+import java.util.*;
+
+/**
+ * 백준 3079
+ * 입국심사
+ * 골드5
+ * https://www.acmicpc.net/problem/3079
+ */
+public class Boj3079 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken()); // 입국심사대 개수
+        int M = Integer.parseInt(st.nextToken()); // 친구들 수
+        int[] t = new int[N]; // 입국심사대별 걸리는 시간
+
+        int max = 1;
+        for(int i = 0; i < N; i++) {
+            t[i] = Integer.parseInt(br.readLine());
+            max = Math.max(max, t[i]);
+        }
+
+        long left = 1;
+        long right = (long) max * M; // 초
+        long answer = right;
+        while(left <= right) {
+            long mid = left + ((right - left) / 2);
+
+            long sum = 0; // 처리할 수 있는 사람 수
+
+            for(int i : t) {
+                sum += mid / i;
+                if(sum > M)
+                    break;
+            }
+
+            if(sum >= M) {
+                right = mid - 1;
+                answer = Math.min(answer, mid);
+            } else {
+                left = mid + 1;
+            }
+        }
+
+        System.out.println(answer);
+
+    }
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 3079:입국심사](BOJ 3079:입국심사)
<br>

## 📱 스크린샷
<img width="734" alt="image" src="https://github.com/user-attachments/assets/2f8ca315-c22c-47b4-a1f3-9c7ad8099f9c">
<br>

## 📝 리뷰 내용
문제를 읽으니 범위가 엄청나고, 최솟값을 찾는 문제더라고요. 바로 이분탐색을 이용한 Lower bound 문제라고 생각했습니다.

총 걸린 시간을 기준으로 이분탐색을 돌렸습니다. 그리고 범위를 나누는 기준은 시간에 따라 처리할 수 있는 친구들 수로 했습니다.

처리할 수 있는 친구의 수는 총 시간에서 심국심사 장소별 걸리는 시간을 나누어 더하는 방식으로 구했습니다.

하지만 범위 초과가 나더라고요. 
원인을 찾아보니, 다음과 같은 상황을 생각해볼 수 있습니다.

친구들 수 * 한 친구당 걸리는 시간 * 임국 심사대 수 == 10^9 * 10^9 * 10^5으로 long 타입 범위를 넘어가는 경우 입니다. 하지만 친구들 수는 M개(최대 10*9)으로 제한되어 있으니 넘어가는 부분은 걸려주어 해결할 수 있습니다.

**느낀점**
구현 과정에서 내가 구현한 부분이 어떤걸 나타내는지 주석을 해놓을 필요가 있다고 느꼈습니다. 이것 저것 생각하면서 했던것들을 놓치고 가더라고요.


