### PR TITLE
BOJ 3079: 입국심사

### DIFF
--- a/limsubin/baekjoon/boj3079.py
+++ b/limsubin/baekjoon/boj3079.py
@@ -1,0 +1,37 @@
+# BOJ 3079: 입국심사
+# https://www.acmicpc.net/problem/3079
+
+import sys
+
+def input():
+    return sys.stdin.readline().strip()
+
+n, m = map(int, input().split())
+
+time = []
+start = float('INF')
+
+for _ in range(n):
+    i = int(input())
+    time.append(i)
+    start = min(start, i) # 시간의 최솟값
+
+end = start * m # 최솟값 m번
+
+while start <= end:
+    mid = (start + end) // 2
+
+    # 심사를 받을 수 있는 사람의 수 세기
+    temp = 0
+    for t in time:
+        temp += mid // t
+
+        # m명이 모두 심사 받을 수 있는 경우
+        if temp >= m:
+            end = mid - 1
+            break
+    # 심사 받을 수 없는 경우
+    else:
+        start = mid + 1
+
+print(start)


### PR DESCRIPTION
## 💡 문제
BOJ 3079: 입국심사
<br>

## 📱 스크린샷
![image](https://github.com/user-attachments/assets/fdde246b-54c5-4df7-9ed4-2f2cb56fe596)
<br>

## 📝 리뷰 내용
처음 접근은 우선 순위 큐를 이용했어요.

```python
import sys
import heapq

def input():
    return sys.stdin.readline().strip()

n, m = map(int, input().split())
hq = []

for _ in range(n):
    i = int(input())
    heapq.heappush(hq, [i, i])

for i in range(m):
    answer, value = heapq.heappop(hq)
    heapq.heappush(hq, [answer + value, value])

print(answer)
```

우선 순위 큐에 [다음 시간, 원래 시간] 을 넣어주고
m번 만큼 빼고 넣고를 반복해서 최솟값을 찾는 거였어요.
시간 초과가 날 거라고 생각했지만 일단 제출해봤고 시간 초과 났습니다~ 하하

그리고 김대영씨가 오늘 푼 문제라고 중얼 중얼 거려서 이분 탐색이구나! 하고 풀었습니다.
시간으로 이분 탐색을 해서 최적의 시간을 찾는 문제였어요.
구현 과정은 같으니 생략~
