### PR TITLE
BOJ 9177: 단어 섞기

### DIFF
--- a/kimdaeyeong/src/baekjoon/Boj9177BFS.java
+++ b/kimdaeyeong/src/baekjoon/Boj9177BFS.java
@@ -1,0 +1,64 @@
+package baekjoon;
+
+import java.util.*;
+import java.io.*;
+
+/**
+ * 백준 9177
+ * 단어 섞기
+ * 골드4
+ * https://www.acmicpc.net/problem/9177
+ */
+public class Boj9177BFS {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine());
+
+        for(int t = 1; t <= T; t++) {
+            st = new StringTokenizer(br.readLine());
+
+            char[] s1 = st.nextToken().toCharArray();
+            char[] s2 = st.nextToken().toCharArray();
+            char[] s3 = st.nextToken().toCharArray();
+
+            sb.append("Data set ").append(t).append(": ").append(bfs(s1, s2, s3)).append("\n");
+        }
+
+        System.out.print(sb);
+    }
+
+    public static String bfs(char[] s1, char[] s2, char[] s3) {
+        Queue<int[]> q = new LinkedList<>();
+        boolean[][] visited = new boolean[201][201];
+
+        q.add(new int[] {0, 0, 0});
+        visited[0][0] = true;
+
+        while(!q.isEmpty()) {
+            int[] cur = q.poll();
+
+            if(cur[2] == s3.length) {
+                return "yes";
+            }
+
+            if(cur[0] < s1.length && !visited[cur[0] + 1][cur[1]] &&
+                    s1[cur[0]] == s3[cur[2]]) {
+                q.add(new int[] {cur[0] + 1, cur[1], cur[2] + 1});
+                visited[cur[0] + 1][cur[1]] = true;
+            }
+
+            if(cur[1] < s2.length && !visited[cur[0]][cur[1] + 1] &&
+                    s2[cur[1]] == s3[cur[2]]) {
+                q.add(new int[] {cur[0], cur[1] + 1, cur[2] + 1});
+                visited[cur[0]][cur[1] + 1] = true;
+            }
+        }
+
+        return "no";
+    }
+
+}


### PR DESCRIPTION
## 💡 문제
[BOJ 9177: 단어 섞기](https://www.acmicpc.net/problem/9177)
<br>

## 📱 스크린샷
<img width="738" alt="image" src="https://github.com/user-attachments/assets/c1841cb1-1403-402a-b0cd-b581e271fc27">
<br>

## 📝 리뷰 내용
처음에 큐 세개에 단어 각각을 담았습니다.
그리고 목표 단어의 첫 글자를 나머지 두 단어의 첫글자와 비교했습니다. 그러면 세가지 상황이 생기는데요.

1. 둘다 같은 경우
2. 한 단어의 첫글자와만 같은 경우
3. 모두 다른 경우

1번의 경우는 각 큐에서 모두 꺼내 다시 넣어줬습니다. 어느곳에 들어갈지 못정하기 때문에 중복된 단어들만 따로 처리하기 위함이였습니다.

2번의 경우 첫글자가 같은 것만 꺼내고 계속 진행합니다.

3번의 경우 목표 단어의 첫글자는 항상 적어도 두 단어의 첫글자중 하나와 일치해야 하는데 그렇지 않은 경우이므로 불가능 처리 하고 끝냅니다.

하지만 틀렸는데요. 반례는 다음과 같습니다.
```
[입력]
2
aaxxp xaxaq aaxaxaqaxp
aaxxp xaxaq axaxaqxaxp

[출력(정답)]
Data set 1: no
Data set 2: no

[출력(59114301)]
Data set 1: no
Data set 2: yes
```
출처: https://www.acmicpc.net/board/view/140717

원인을 분석해보자면 1번의 경우 중복 단어들을 나중에 처리 한다고 해도 결국엔 두 경우중 하나를 골라야 하는 상황이 오는데 이를 결정할 방법이 없기 때문입니다.

더이상 마땅한 풀이 방법이 떠오르지 않아 풀이를 봤는데 bfs나 dp를 이용하면 되는 문제 였습니다. 저는 문제를 읽고 dp 보다는 bfs 쪽 풀이가 더 머리에 잘들어와서 bfs를 이용했습니다.

핵심은 목표 단어의 인덱스에서 탐색할 수 있는 방법은 첫번째 단어의 인덱스, 두번째 단어의 인덱스 두가지 경우 입니다. 이 때 문자가 같다면 다음 탐색을 이어가고 그렇지 않다면 탐색을 멈추는 방식입니다.

**느낀점**
bfs 탐색 문제는 자신 있었는데 아직 갈길이 멀다는것을 알았습니다. 또한 dp의 점화식을 찾는건 쉽지 않네요.